### PR TITLE
display hand size

### DIFF
--- a/components/Game/Hand/hand.container.tsx
+++ b/components/Game/Hand/hand.container.tsx
@@ -93,7 +93,9 @@ export const HandContainer = ({
         >
           Draw + 1
         </ModalButton>
-        <ModalButton onClick={() => setModal("deck")}>Deck</ModalButton>
+        <ModalButton onClick={() => setModal("deck")}>
+          Deck ({playerState?.pool?.deck?.length})
+        </ModalButton>
         <ModalButton onClick={() => setModal("discard")}>Discard</ModalButton>
         {playerState?.pool?.commit?.boost && (
           <ModalButton


### PR DESCRIPTION
There is a particular use case where displaying the number of cards left in the deck is necessary to preserve game the game logic.

If a user topdecks a card and then checks the deck by opening a modal, the deck is reshuffled, and the card is no longer topdecked.

Therefore, there needs to be another instance of communication how much cards is left in the deck, in addition to just checking the deck modal.

I've added that communication in a very simple way in this request. 