### PR TITLE
Feat/add boost from top of deck

### DIFF
--- a/components/DeckPool/PoolFns.ts
+++ b/components/DeckPool/PoolFns.ts
@@ -193,6 +193,22 @@ export const boostCard = (pool: PoolType, cardIndex: number): PoolType => {
   return pool;
 };
 
+export const boostFromTopDeck = (pool: PoolType): PoolType => {
+  if (!pool?.deck) return pool;
+  if (!pool?.hand) return pool;
+  if (pool.commit.boost) return pool;
+
+  if (pool.deck.length === 0) {
+    alert("No cards left");
+  }
+  const card = pool?.deck?.pop();
+  if (card) {
+    pool.commit.boost = card;
+  }
+
+  return pool;
+};
+
 export const cancelBoost = (pool: PoolType): PoolType => {
   if (!pool?.commit.boost) return pool;
   pool.hand.unshift(pool.commit.boost);

--- a/components/Game/game.carousel.tsx
+++ b/components/Game/game.carousel.tsx
@@ -1,19 +1,10 @@
 //@ts-nocheck
 import { mockDeck } from "@/_mocks_/deck";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useRef, useState } from "react";
 import AliceCarousel from "react-alice-carousel";
 import "react-alice-carousel/lib/alice-carousel.css";
 import { CardFactory } from "../CardFactory/card.factory";
-import {
-  Box,
-  Button,
-  Flex,
-  Popover,
-  Select,
-  Skeleton,
-  Spacer,
-  Text,
-} from "@chakra-ui/react";
+import { Box, Flex, Skeleton, Spacer, Text } from "@chakra-ui/react";
 import {
   DeckImportCardType,
   DeckImportType,

--- a/components/Game/game.modal-body.tsx
+++ b/components/Game/game.modal-body.tsx
@@ -5,6 +5,7 @@ import { PoolType } from "../DeckPool/PoolFns";
 import { useState } from "react";
 
 import { GiUpgrade as IconBoost } from "react-icons/gi";
+import { PopoverCardActions } from "./card-actions.popover";
 
 export const DeckModalContent = ({
   cards,
@@ -55,7 +56,8 @@ export const CommitModalContent: React.FC<{
   onClose: () => void;
   onFlip: () => void;
   onDiscard: () => void;
-}> = ({ commits, onClose, onFlip, onDiscard }) => {
+  onBoostTopDeck: () => void;
+}> = ({ commits, onClose, onFlip, onDiscard, onBoostTopDeck }) => {
   return (
     <Flex flexDir="column" justifyContent="space-evenly" gap={3} minH={"40svh"}>
       <Flex
@@ -72,6 +74,17 @@ export const CommitModalContent: React.FC<{
         <Button onClick={onClose}>Cancel</Button>
         <Button onClick={onFlip}>Flip</Button>
         <Button onClick={onDiscard}>Discard</Button>
+
+        <div style={{ fontSize: "2rem" }}>
+          <PopoverCardActions
+            actions={[
+              {
+                text: "Boost from top of deck",
+                fn: onBoostTopDeck,
+              },
+            ]}
+          />
+        </div>
       </Flex>
     </Flex>
   );

--- a/components/Game/game.modal-template.tsx
+++ b/components/Game/game.modal-template.tsx
@@ -13,7 +13,6 @@ import {
   PlayerCommit,
 } from "./game.modal-body";
 import { ModalType } from "@/pages/game";
-import { useWebGame } from "@/lib/contexts/WebGameProvider";
 import {
   PoolType,
   boostFromTopDeck,

--- a/components/Game/game.modal-template.tsx
+++ b/components/Game/game.modal-template.tsx
@@ -16,6 +16,7 @@ import { ModalType } from "@/pages/game";
 import { useWebGame } from "@/lib/contexts/WebGameProvider";
 import {
   PoolType,
+  boostFromTopDeck,
   cancelCommit,
   discardCommit,
   drawDeck,
@@ -88,6 +89,11 @@ export const ModalContainer: React.FC<ModalTemplateType> = ({
       setGameState,
     );
 
+  const gBoostTopDeck = flow(
+    () => playerState?.pool && boostFromTopDeck(playerState?.pool),
+    setGameState,
+  );
+
   const gDrawDeck = (discardIndex: number) =>
     flow(
       () => playerState?.pool && drawDeck(playerState?.pool, discardIndex),
@@ -141,6 +147,7 @@ export const ModalContainer: React.FC<ModalTemplateType> = ({
                 commits={commits}
                 onFlip={gFlip}
                 onDiscard={gDiscardCommit}
+                onBoostTopDeck={gBoostTopDeck}
               />
             )}
           </ModalBody>


### PR DESCRIPTION
## Request

> nitetrio — 11/05/2024
This is how image it the after flipping the card the player can either BOOST (hand) or BLIND BOOST (top deck) their cards on the COMMIT interface. Just a request if possible😁 🙏

![image](https://github.com/user-attachments/assets/036e0e9c-6ce5-4709-bb2f-a4fa028f6ac4)

---

## Solution

Adding boost from top of deck as a misc option on the flip screen. Using a small popover to avoid drawing too much attention to it, since it's used in a niche amount of decks.

Going to skip boosting from hand option. Boosting from hand would require creating another modal to select the card from. Right now you can cancel, boost, and re-flip the cards again. Since the enemy knows what card you played, you won't be able to "cheat" boosting from hand. 

https://github.com/user-attachments/assets/fb07c145-6cf0-4dd5-9a87-2fef0339c525

![image](https://github.com/user-attachments/assets/831e006f-297d-440c-bff4-16f2948cd823)


